### PR TITLE
added the property ea.rabbitmq.prefetchSize

### DIFF
--- a/messaging-rabbitmq/src/main/java/org/elasticsoftware/elasticactors/configuration/MessagingConfiguration.java
+++ b/messaging-rabbitmq/src/main/java/org/elasticsoftware/elasticactors/configuration/MessagingConfiguration.java
@@ -60,6 +60,7 @@ public class MessagingConfiguration {
         String rabbitMQPassword = env.getProperty("ea.rabbitmq.password","guest");
         MessageAcker.Type ackType = env.getProperty("ea.rabbitmq.ack",MessageAcker.Type.class, DIRECT);
         String threadModel = env.getProperty("ea.rabbitmq.threadmodel", "sc");
+        Integer prefetchCount = env.getProperty("ea.rabbitmq.prefetchCount", Integer.class, 0);
         if("cpt".equals(threadModel)) {
             messagingService = new org.elasticsoftware.elasticactors.rabbitmq.cpt.RabbitMQMessagingService(clusterName,
                     rabbitMQHosts,
@@ -68,7 +69,8 @@ public class MessagingConfiguration {
                     rabbitMQPassword,
                     ackType,
                     queueExecutor,
-                    new InternalMessageDeserializer(new ActorRefDeserializer(actorRefFactory), internalActorSystem));
+                    new InternalMessageDeserializer(new ActorRefDeserializer(actorRefFactory), internalActorSystem),
+                    prefetchCount);
         } else {
             messagingService = new RabbitMQMessagingService(clusterName,
                     rabbitMQHosts,
@@ -77,7 +79,7 @@ public class MessagingConfiguration {
                     rabbitMQPassword,
                     ackType,
                     queueExecutor,
-                    new InternalMessageDeserializer(new ActorRefDeserializer(actorRefFactory), internalActorSystem));
+                    new InternalMessageDeserializer(new ActorRefDeserializer(actorRefFactory), internalActorSystem), prefetchCount);
         }
     }
 

--- a/messaging-rabbitmq/src/main/java/org/elasticsoftware/elasticactors/rabbitmq/LocalMessageQueue.java
+++ b/messaging-rabbitmq/src/main/java/org/elasticsoftware/elasticactors/rabbitmq/LocalMessageQueue.java
@@ -131,7 +131,6 @@ public final class LocalMessageQueue extends DefaultConsumer implements MessageQ
 
     @Override
     public void initialize() throws Exception {
-        consumerChannel.basicQos(0);
         consumerChannel.basicConsume(queueName,false,this);
     }
 

--- a/messaging-rabbitmq/src/test/java/org/elasticsoftware/elasticactors/rabbitmq/RabbitMQMessagingServiceTest.java
+++ b/messaging-rabbitmq/src/test/java/org/elasticsoftware/elasticactors/rabbitmq/RabbitMQMessagingServiceTest.java
@@ -86,7 +86,7 @@ public class RabbitMQMessagingServiceTest {
                                                                                  5672, System.getProperty("username","guest"),
                                                                                  System.getProperty("password","guest"),
                                                                                  MessageAcker.Type.DIRECT,
-                                                                                 queueExecutor, new InternalMessageDeserializer(new ActorRefDeserializer(actorRefFactory), internalActorSystem));
+                                                                                 queueExecutor, new InternalMessageDeserializer(new ActorRefDeserializer(actorRefFactory), internalActorSystem), 10);
         messagingService.start();
 
         final CountDownLatch waitLatch = new CountDownLatch(NUM_MESSAGES);


### PR DESCRIPTION
This should make sure when there are messages piling up the rabbitmq consumers are not overloaded (and causing gc troubles) with cached messages. The default is still 0 (which is the current fixed setting) but I think setting this to 100 might be a good start