### PR TITLE
ShardedScheduler fixes

### DIFF
--- a/core/src/main/java/org/elasticsoftware/elasticactors/cluster/scheduler/ShardedScheduler.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/cluster/scheduler/ShardedScheduler.java
@@ -91,13 +91,13 @@ public final class ShardedScheduler implements SchedulerService,WorkExecutorFact
         workManager.registerShard(shardKey);
         // fetch block from repository
         // @todo: for now we'll fetch all, this obviously has memory issues
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         List<ScheduledMessage> scheduledMessages = scheduledMessageRepository.getAll(shardKey);
         if(logger.isInfoEnabled()) {
-            logger.info("Registering shard {} and loaded {} scheduled messages in {} milliseconds",
+            logger.info("Registering shard {} and loaded {} scheduled messages in {} nanoseconds",
                     shardKey.toString(),
                     scheduledMessages.size(),
-                    System.currentTimeMillis() - startTime);
+                    System.nanoTime() - startTime);
         }
         workManager.schedule(shardKey,scheduledMessages.toArray(new ScheduledMessage[scheduledMessages.size()]));
     }

--- a/core/src/main/java/org/elasticsoftware/elasticactors/cluster/scheduler/ShardedScheduler.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/cluster/scheduler/ShardedScheduler.java
@@ -91,9 +91,9 @@ public final class ShardedScheduler implements SchedulerService,WorkExecutorFact
         workManager.registerShard(shardKey);
         // fetch block from repository
         // @todo: for now we'll fetch all, this obviously has memory issues
+        long startTime = System.currentTimeMillis();
         List<ScheduledMessage> scheduledMessages = scheduledMessageRepository.getAll(shardKey);
         if(logger.isInfoEnabled()) {
-            long startTime = System.currentTimeMillis();
             logger.info("Registering shard {} and loaded {} scheduled messages in {} milliseconds",
                     shardKey.toString(),
                     scheduledMessages.size(),

--- a/core/src/main/java/org/elasticsoftware/elasticactors/util/concurrent/ShardedScheduledWorkManager.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/util/concurrent/ShardedScheduledWorkManager.java
@@ -237,14 +237,7 @@ public final class ShardedScheduledWorkManager<K,T extends Delayed> {
                     }
                 }
             } finally {
-                infoMessage("Worker thread stopped");
-            }
-        }
-
-        private void infoMessage(String messageFormat, Object... args) {
-            if (LOGGER.isInfoEnabled()) {
-                String formattedMessage = format(messageFormat, args);
-                LOGGER.info(formattedMessage);
+                LOGGER.info("Worker thread stopped");
             }
         }
     }

--- a/core/src/main/java/org/elasticsoftware/elasticactors/util/concurrent/ShardedScheduledWorkManager.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/util/concurrent/ShardedScheduledWorkManager.java
@@ -77,8 +77,8 @@ public final class ShardedScheduledWorkManager<K,T extends Delayed> {
         stop = false;
         for (int i = 0; i < numberOfWorkers; i++) {
             Future<?> future = useNonBlockingWorker ?
-                    executor.submit(new RunnableWorker(workerFactory.create())) :
-                    executor.submit(new NonBlockingRunnableWorker(workerFactory.create()));
+                    executor.submit(new NonBlockingRunnableWorker(workerFactory.create())) :
+                    executor.submit(new RunnableWorker(workerFactory.create()));
             futures.add(future);
         }
     }
@@ -216,11 +216,10 @@ public final class ShardedScheduledWorkManager<K,T extends Delayed> {
         public void run() {
             try {
                 while (!stop) {
-                    T work = null;
                     // pick a random queue to block on if there are no Delayed object younger than MAX_AWAIT_MILLIS
                     for (Map.Entry<K, DelayQueue<T>> delayQueueEntry : delayQueues.entrySet()) {
                         final DelayQueue<T> delayQueue = delayQueueEntry.getValue();
-                        work = delayQueue.poll();
+                        T work = delayQueue.poll();
                         if(work != null) {
                             try {
                                 workExecutor.execute(delayQueueEntry.getKey(),work);

--- a/core/src/main/java/org/elasticsoftware/elasticactors/util/concurrent/ShardedScheduledWorkManager.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/util/concurrent/ShardedScheduledWorkManager.java
@@ -217,7 +217,6 @@ public final class ShardedScheduledWorkManager<K,T extends Delayed> {
             try {
                 while (!stop) {
                     T work = null;
-                    long waitTimeMillis = MAX_AWAIT_MILLIS;
                     // pick a random queue to block on if there are no Delayed object younger than MAX_AWAIT_MILLIS
                     for (Map.Entry<K, DelayQueue<T>> delayQueueEntry : delayQueues.entrySet()) {
                         final DelayQueue<T> delayQueue = delayQueueEntry.getValue();

--- a/runtime/src/main/java/org/elasticsoftware/elasticactors/configuration/NodeConfiguration.java
+++ b/runtime/src/main/java/org/elasticsoftware/elasticactors/configuration/NodeConfiguration.java
@@ -55,6 +55,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Map;
 
+import static java.lang.Boolean.FALSE;
+
 /**
  * @author Joost van de Wijgerd
  */
@@ -98,7 +100,7 @@ public class NodeConfiguration {
     @Bean(name = {"objectMapper"})
     public ObjectMapper createObjectMapper(ShardedScheduler schedulerService) {
         String basePackages = env.getProperty("ea.scan.packages",String.class,"");
-        Boolean useAfterburner = env.getProperty("ea.base.useAfterburner",Boolean.class,Boolean.FALSE);
+        Boolean useAfterburner = env.getProperty("ea.base.useAfterburner",Boolean.class, FALSE);
         // @todo: fix version
         ObjectMapperBuilder builder = new ObjectMapperBuilder(node,schedulerService,"1.0.0",basePackages);
         builder.setUseAfterBurner(useAfterburner);
@@ -141,7 +143,7 @@ public class NodeConfiguration {
     @DependsOn("asyncUpdateExecutor")
     public ThreadBoundExecutor createActorExecutor() {
         final int workers = env.getProperty("ea.actorExecutor.workerCount",Integer.class,Runtime.getRuntime().availableProcessors() * 3);
-        final Boolean useDisruptor = env.getProperty("ea.actorExecutor.useDisruptor",Boolean.class,Boolean.FALSE);
+        final Boolean useDisruptor = env.getProperty("ea.actorExecutor.useDisruptor",Boolean.class, FALSE);
         if(useDisruptor) {
             return new org.elasticsoftware.elasticactors.util.concurrent.disruptor.ThreadBoundExecutorImpl(new DaemonThreadFactory("ACTOR-WORKER"),workers);
         } else {
@@ -153,7 +155,7 @@ public class NodeConfiguration {
     @DependsOn("actorExecutor")
     public ThreadBoundExecutor createQueueExecutor() {
         final int workers = env.getProperty("ea.queueExecutor.workerCount",Integer.class,Runtime.getRuntime().availableProcessors() * 3);
-        final Boolean useDisruptor = env.getProperty("ea.actorExecutor.useDisruptor",Boolean.class,Boolean.FALSE);
+        final Boolean useDisruptor = env.getProperty("ea.actorExecutor.useDisruptor",Boolean.class, FALSE);
         if(useDisruptor) {
             return new org.elasticsoftware.elasticactors.util.concurrent.disruptor.ThreadBoundExecutorImpl(new DaemonThreadFactory("QUEUE-WORKER"), workers);
         } else {
@@ -173,8 +175,9 @@ public class NodeConfiguration {
 
     @Bean(name = {"scheduler"})
     public ShardedScheduler createScheduler() {
-        //@todo: maybe configure scheduler here with number of workers
-        return new ShardedScheduler();
+        int numberOfWorkers = env.getProperty("ea.shardedScheduler.workerCount", Integer.class, Runtime.getRuntime().availableProcessors());
+        Boolean useNonBlockingWorker = env.getProperty("ea.shardedScheduler.useNonBlockingWorker", Boolean.class, FALSE);
+        return new ShardedScheduler(numberOfWorkers, useNonBlockingWorker);
     }
 
     @Bean(name = {"actorSystemEventListenerService"})

--- a/spi/src/main/java/org/elasticsoftware/elasticactors/cluster/InternalActorSystem.java
+++ b/spi/src/main/java/org/elasticsoftware/elasticactors/cluster/InternalActorSystem.java
@@ -55,6 +55,10 @@ public interface InternalActorSystem extends ActorSystem, ShardAccessor {
      */
     ElasticActor getServiceInstance(ActorRef serviceRef);
 
+    default void shutdown() {
+
+    }
+
     /**
      * Returns a {@link ActorNode} that can be either remote or local
      *


### PR DESCRIPTION
added 2 properties to control the inner workings of the ShardedSheduler (setting the number of worker threads and the type of worker: blocking (using semaphore) vs non-blocking (using Thread.sleep)

added info logging fo the loading of the scheduled messages