### PR TITLE
Limit the maximum message body length for logging

### DIFF
--- a/api/src/main/java/org/elasticsoftware/elasticactors/MethodActor.java
+++ b/api/src/main/java/org/elasticsoftware/elasticactors/MethodActor.java
@@ -173,7 +173,7 @@ public abstract class MethodActor extends TypedActor<Object> implements Persiste
                             "Unexpected Exception in handler method [{}]. "
                                     + "Actor [{}]. "
                                     + "Sender [{}]. "
-                                    + "Message payload: [{}]",
+                                    + "Message payload [{}]",
                             definition.handlerMethod,
                             getSelf(),
                             sender,
@@ -191,7 +191,7 @@ public abstract class MethodActor extends TypedActor<Object> implements Persiste
                 "Unhandled message of type [{}] received. "
                         + "Actor [{}]. "
                         + "Sender [{}]. "
-                        + "Message payload: [{}]",
+                        + "Message payload [{}]",
                 message.getClass().getName(),
                 getSelf(),
                 sender,

--- a/api/src/main/java/org/elasticsoftware/elasticactors/MethodActor.java
+++ b/api/src/main/java/org/elasticsoftware/elasticactors/MethodActor.java
@@ -173,7 +173,7 @@ public abstract class MethodActor extends TypedActor<Object> implements Persiste
                             "Unexpected Exception in handler method [{}]. "
                                     + "Actor [{}]. "
                                     + "Sender [{}]. "
-                                    + "Message payload: {}",
+                                    + "Message payload: [{}]",
                             definition.handlerMethod,
                             getSelf(),
                             sender,
@@ -191,7 +191,7 @@ public abstract class MethodActor extends TypedActor<Object> implements Persiste
                 "Unhandled message of type [{}] received. "
                         + "Actor [{}]. "
                         + "Sender [{}]. "
-                        + "Message payload: {}",
+                        + "Message payload: [{}]",
                 message.getClass().getName(),
                 getSelf(),
                 sender,

--- a/api/src/main/java/org/elasticsoftware/elasticactors/MethodActor.java
+++ b/api/src/main/java/org/elasticsoftware/elasticactors/MethodActor.java
@@ -173,7 +173,7 @@ public abstract class MethodActor extends TypedActor<Object> implements Persiste
                             "Unexpected Exception in handler method [{}]. "
                                     + "Actor [{}]. "
                                     + "Sender [{}]. "
-                                    + "Message payload [{}]",
+                                    + "Message payload [{}].",
                             definition.handlerMethod,
                             getSelf(),
                             sender,
@@ -191,7 +191,7 @@ public abstract class MethodActor extends TypedActor<Object> implements Persiste
                 "Unhandled message of type [{}] received. "
                         + "Actor [{}]. "
                         + "Sender [{}]. "
-                        + "Message payload [{}]",
+                        + "Message payload [{}].",
                 message.getClass().getName(),
                 getSelf(),
                 sender,

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>elasticactors-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/base/src/main/java/org/elasticsoftware/elasticactors/base/serialization/JacksonMessageToStringSerializer.java
+++ b/base/src/main/java/org/elasticsoftware/elasticactors/base/serialization/JacksonMessageToStringSerializer.java
@@ -22,13 +22,19 @@ import org.elasticsoftware.elasticactors.serialization.MessageToStringSerializer
 public final class JacksonMessageToStringSerializer<T> implements MessageToStringSerializer<T> {
 
     private final ObjectMapper objectMapper;
+    private final int maxLength;
 
-    public JacksonMessageToStringSerializer(ObjectMapper objectMapper) {
+    public JacksonMessageToStringSerializer(ObjectMapper objectMapper, int maxLength) {
         this.objectMapper = objectMapper;
+        this.maxLength = maxLength;
     }
 
     @Override
     public String serialize(T message) throws Exception {
-        return objectMapper.writeValueAsString(message);
+        String serialized = objectMapper.writeValueAsString(message);
+        if (serialized.length() > maxLength) {
+            serialized = "[CONTENT_TOO_BIG]: " + serialized.substring(0, maxLength);
+        }
+        return serialized;
     }
 }

--- a/base/src/main/java/org/elasticsoftware/elasticactors/base/serialization/JacksonMessageToStringSerializer.java
+++ b/base/src/main/java/org/elasticsoftware/elasticactors/base/serialization/JacksonMessageToStringSerializer.java
@@ -32,7 +32,7 @@ public final class JacksonMessageToStringSerializer<T> implements MessageToStrin
     @Override
     public String serialize(T message) throws Exception {
         String serialized = objectMapper.writeValueAsString(message);
-        if (serialized.length() > maxLength) {
+        if (serialized != null && serialized.length() > maxLength) {
             serialized = "[CONTENT_TOO_BIG]: " + serialized.substring(0, maxLength);
         }
         return serialized;

--- a/base/src/main/java/org/elasticsoftware/elasticactors/base/serialization/JacksonSerializationFramework.java
+++ b/base/src/main/java/org/elasticsoftware/elasticactors/base/serialization/JacksonSerializationFramework.java
@@ -26,6 +26,7 @@ import org.elasticsoftware.elasticactors.serialization.MessageSerializer;
 import org.elasticsoftware.elasticactors.serialization.MessageToStringSerializer;
 import org.elasticsoftware.elasticactors.serialization.SerializationFramework;
 import org.elasticsoftware.elasticactors.serialization.Serializer;
+import org.springframework.beans.factory.annotation.Value;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -37,18 +38,31 @@ import java.util.concurrent.ConcurrentMap;
  */
 @Named
 public final class JacksonSerializationFramework implements SerializationFramework {
-    private final ConcurrentMap<Class,JacksonMessageDeserializer> deserializers = new ConcurrentHashMap<>();
+
+    public final static int DEFAULT_MAX_LENGTH = 500_000;
+
+    private static final String MAX_LENGTH_CONFIGURATION_KEY =
+            "${ea.serialization.string.maxLength:" + DEFAULT_MAX_LENGTH + "}";
+
+    private final ConcurrentMap<Class, JacksonMessageDeserializer> deserializers =
+            new ConcurrentHashMap<>();
     private final JacksonMessageSerializer serializer;
     private final JacksonMessageToStringSerializer toStringSerializer;
     private final ObjectMapper objectMapper;
     private final JacksonActorStateSerializer actorStateSerializer;
     private final JacksonActorStateDeserializer actorStateDeserializer;
 
-    @Inject
     public JacksonSerializationFramework(ObjectMapper objectMapper) {
+        this(objectMapper, DEFAULT_MAX_LENGTH);
+    }
+
+    @Inject
+    public JacksonSerializationFramework(
+            ObjectMapper objectMapper,
+            @Value(MAX_LENGTH_CONFIGURATION_KEY) int maxLength) {
         this.objectMapper = objectMapper;
         this.serializer = new JacksonMessageSerializer(objectMapper);
-        this.toStringSerializer = new JacksonMessageToStringSerializer(objectMapper);
+        this.toStringSerializer = new JacksonMessageToStringSerializer(objectMapper, maxLength);
         this.actorStateSerializer = new JacksonActorStateSerializer(objectMapper);
         this.actorStateDeserializer = new JacksonActorStateDeserializer(objectMapper);
     }

--- a/core/src/main/java/org/elasticsoftware/elasticactors/cluster/tasks/app/HandleMessageTask.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/cluster/tasks/app/HandleMessageTask.java
@@ -117,7 +117,7 @@ public final class HandleMessageTask extends ActorLifecycleTask {
                             "Exception while handling message of type [{}]. "
                                     + "Actor [{}]. "
                                     + "Sender [{}]. "
-                                    + "Message payload: [{}]",
+                                    + "Message payload [{}]",
                             internalMessage.getPayloadClass(),
                             receiverRef,
                             internalMessage.getSender(),

--- a/core/src/main/java/org/elasticsoftware/elasticactors/cluster/tasks/app/HandleMessageTask.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/cluster/tasks/app/HandleMessageTask.java
@@ -117,7 +117,7 @@ public final class HandleMessageTask extends ActorLifecycleTask {
                             "Exception while handling message of type [{}]. "
                                     + "Actor [{}]. "
                                     + "Sender [{}]. "
-                                    + "Message payload [{}]",
+                                    + "Message payload [{}].",
                             internalMessage.getPayloadClass(),
                             receiverRef,
                             internalMessage.getSender(),

--- a/core/src/main/java/org/elasticsoftware/elasticactors/cluster/tasks/app/HandleMessageTask.java
+++ b/core/src/main/java/org/elasticsoftware/elasticactors/cluster/tasks/app/HandleMessageTask.java
@@ -117,7 +117,7 @@ public final class HandleMessageTask extends ActorLifecycleTask {
                             "Exception while handling message of type [{}]. "
                                     + "Actor [{}]. "
                                     + "Sender [{}]. "
-                                    + "Message payload: {}",
+                                    + "Message payload: [{}]",
                             internalMessage.getPayloadClass(),
                             receiverRef,
                             internalMessage.getSender(),


### PR DESCRIPTION
This works perfectly (at least in cfd-platform), compiles just fine in case someone is instantiating the serialization framework by hand, and it's minimal :-)